### PR TITLE
Fails on pip3 because magenta is only available for Python 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ To install the rest of the back-end requirements (make sure you have python and 
 
 ```bash
 cd server
-pip install -r requirements.txt
+pip2 install -r requirements.txt
 ```
 
 Then run the server:


### PR DESCRIPTION
I actually also had to add:

```
https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-0.11.0-py2-none-any.whl
ipython==3.2.0
```

To `requirements.txt` but the tensorflow link is macOS specific.

#### Just a little story 😄 

Then I got:

```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 1988, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 1641, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 1544, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 1639, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 1625, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "server.py", line 39, in predict
    ret_midi = generate_midi(midi_data, duration)
  File "/Users/d/src/clones/aiexperiments-ai-duet/server/predict.py", line 52, in generate_midi
    generate_response = basic_generator.generate(generate_request)
TypeError: generate() takes exactly 3 arguments (2 given)
```

Then I was just like, ok sure let's give it a third argument 😄 : 

```
details = generator_pb2.GeneratorDetails(id='test_generator', description='Test Generator')
generate_response = basic_generator.generate(generate_request, details)
```

How naive I was 😄 : 

```
  File "/Users/d/src/clones/aiexperiments-ai-duet/server/predict.py", line 53, in generate_midi
    generate_response = basic_generator.generate(generate_request, details)
  File "/usr/local/lib/python2.7/site-packages/magenta/music/sequence_generator.py", line 225, in generate
    self.initialize()
  File "/usr/local/lib/python2.7/site-packages/magenta/music/sequence_generator.py", line 187, in initialize
    checkpoint_filename, metagraph_filename)
  File "/usr/local/lib/python2.7/site-packages/magenta/models/shared/melody_rnn_sequence_generator.py", line 82, in _initialize_with_checkpoint_and_metagraph
    new_saver = tf.train.import_meta_graph(metagraph_filename)
  File "/usr/local/lib/python2.7/site-packages/tensorflow/python/training/saver.py", line 1415, in import_meta_graph
    return _import_meta_graph_def(read_meta_graph_file(meta_graph_or_file))
  File "/usr/local/lib/python2.7/site-packages/tensorflow/python/training/saver.py", line 1305, in _import_meta_graph_def
    importer.import_graph_def(meta_graph_def.graph_def, name="")
  File "/usr/local/lib/python2.7/site-packages/tensorflow/python/framework/importer.py", line 228, in import_graph_def
    op_def = op_dict[node.op]
KeyError: u'StridedSlice'
```

Then, why not, I upgraded to tensorflow 0.11 (in `requirements.txt`):

```
https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-0.11.0-py2-none-any.whl
```

Then I realized I was not supposed to pass a `GeneratorDetails` 😢  (`def generate(self, input_sequence, generator_options):`) but a `GeneratorOptions` 😄 ...

Ok, cheating time, what about `None` 😄 :

```
if len(generator_options.generate_sections) != 1:
      raise magenta.music.SequenceGeneratorException(...
```

Not cool, I need some `generate_sections`... ok, tricky, [it's a protobuf object](https://github.com/tensorflow/magenta/blob/da877b47050c29ba30dfb8034511ccb1b524af21/magenta/protobuf/generator.proto).

```
generator_options = generator_pb2.GeneratorOptions()
generate_response = basic_generator.generate(generate_request, generator_options)
```

Mouahahah that was easy 😄 , "*Not so fast, human learning machine*' - TensorFlow:

```
SequenceGeneratorException: This model supports only 1 generate_sections message, but got 0
```

That's when I saw #1, thanks @camiblanch because it works! Yeah finally I could play some music with an AI :)