### PR TITLE
Add instructions for cloning the repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ Built by [Yotam Mann](https://github.com/tambien) with friends on the Magenta an
 
 A.I. Duet is composed of two parts, the front-end which is in the `static` folder and the back-end which is in the `server` folder. The front-end client creates short MIDI files using the players's input which is sent to a [Flask](http://flask.pocoo.org/) server. The server takes that MIDI input and "continues" it using [Magenta](https://github.com/tensorflow/magenta) and [TensorFlow](https://www.tensorflow.org/) which is then returned back to the client. 
 
+## CLONING THE REPOSITORY
+
+To clone the repository, use the following command:
+
+```bash
+gh repo clone googlecreativelab/aiexperiments-ai-duet
+```
+
 ## INSTALLATION
 
 A.I. Duet only works with [Python 2.7](https://www.python.org/download/releases/2.7/) and it was tested with Node v6. There are two basic ways of installing A.I. Duet: with Docker or without Docker.


### PR DESCRIPTION
Add a section for cloning the repository using `gh repo clone googlecreativelab/aiexperiments-ai-duet` in the `README.md` file.

* **Cloning the Repository**
  - Add a new section titled "CLONING THE REPOSITORY" before the "INSTALLATION" section.
  - Provide the command `gh repo clone googlecreativelab/aiexperiments-ai-duet` for cloning the repository.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/googlecreativelab/aiexperiments-ai-duet/pull/50?shareId=e75a9a40-d6c8-444f-9648-09e001a85462).